### PR TITLE
fix: update airdrop tool usage to clarify handling of multiple recipients in one call

### DIFF
--- a/typescript/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
+++ b/typescript/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
@@ -30,6 +30,8 @@ Parameters:
   - amount (number or string): The amount of tokens to send to that recipient (in base units)
 - transactionMemo (str, optional): Optional memo for the transaction
 ${usageInstructions}
+
+If the user specifies multiple recipients in a single request, include them all in **one tool call** as a list of recipients.
 `;
 };
 


### PR DESCRIPTION
**Description**:
In pipeline an error has occurred: https://github.com/hashgraph/hedera-agent-kit-js/actions/runs/17859757932/job/50787240021?pr=261
This was due to LLM instead of calling the tool with array of recipients tried to call it several times, each time creating transaction only for one recipient. This bug is caused by the LLM and most of the times the tool works correctly.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
