### PR TITLE
test: temporarily skip tool-calling integration tests

### DIFF
--- a/typescript/test/integration/tool-matching/airdrop-fungible-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/airdrop-fungible-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreTokenPluginToolNames } from '@/plugins';
 
-describe('Airdrop Fungible Token Tool Matching Integration Tests', () => {
+describe.skip('Airdrop Fungible Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Airdrop Fungible Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match airdrop tool with minimal params', async () => {
       const input = 'Airdrop 10 HTS tokens 0.0.1234 from 0.0.1001 to 0.0.2002';
 
@@ -118,7 +118,7 @@ describe('Airdrop Fungible Token Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Availability', () => {
+  describe.skip('Tool Availability', () => {
     it('should have airdrop fungible token tool available', () => {
       const tools = toolkit.getTools();
       const airdropTool = tools.find(tool => tool.name === 'airdrop_fungible_token_tool');

--- a/typescript/test/integration/tool-matching/create-account-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-account-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Create Account Tool Matching Integration Tests', () => {
+describe.skip('Create Account Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Create Account Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match create account tool with default params', async () => {
       const input = 'Create a new Hedera account';
 
@@ -113,7 +113,7 @@ describe('Create Account Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create account tool available', () => {
       const tools = toolkit.getTools();
       const createAccount = tools.find(tool => tool.name === 'create_account_tool');

--- a/typescript/test/integration/tool-matching/create-erc20-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-erc20-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { CREATE_ERC20_TOOL } from '@/plugins/core-evm-plugin/tools/erc20/create-erc20';
 
-describe('Create ERC20 Tool Matching Integration Tests', () => {
+describe.skip('Create ERC20 Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Create ERC20 Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match simple create ERC20 command', async () => {
       const input = 'Create an ERC20 token named TestToken with symbol TST and 1000 initial supply';
 
@@ -115,7 +115,7 @@ describe('Create ERC20 Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create ERC20 tool available', () => {
       const tools = toolkit.getTools();
       const createERC20 = tools.find(tool => tool.name === 'create_erc20_tool');

--- a/typescript/test/integration/tool-matching/create-erc721-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-erc721-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { CREATE_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/create-erc721';
 
-describe('Create ERC721 Tool Matching Integration Tests', () => {
+describe.skip('Create ERC721 Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Create ERC721 Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match simple create ERC721 command', async () => {
       const input = 'Create an ERC721 token named ArtCollection with symbol ART and base URI https://example.com/metadata/';
 
@@ -150,7 +150,7 @@ describe('Create ERC721 Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create ERC721 tool available', () => {
       const tools = toolkit.getTools();
       const createERC721 = tools.find(tool => tool.name === 'create_erc721_tool');

--- a/typescript/test/integration/tool-matching/create-fungible-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-fungible-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreTokenPluginToolNames } from '@/plugins';
 
-describe('Create Fungible Token Tool Matching Integration Tests', () => {
+describe.skip('Create Fungible Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Create Fungible Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match create fungible token tool with minimal params', async () => {
       const input = 'Create a new fungible token called MyToken with symbol MTK';
 
@@ -120,7 +120,7 @@ describe('Create Fungible Token Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create fungible token tool available', () => {
       const tools = toolkit.getTools();
       const createFT = tools.find(tool => tool.name === 'create_fungible_token_tool');

--- a/typescript/test/integration/tool-matching/create-non-fungible-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-non-fungible-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreTokenPluginToolNames } from '@/plugins';
 
-describe('Create Non-Fungible Token Tool Matching Integration Tests', () => {
+describe.skip('Create Non-Fungible Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Create Non-Fungible Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match create non-fungible token tool with minimal params', async () => {
       const input = 'Create a new non-fungible token called MyNFT with symbol MNFT';
 
@@ -114,7 +114,7 @@ describe('Create Non-Fungible Token Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create non-fungible token tool available', () => {
       const tools = toolkit.getTools();
       const createNFT = tools.find(tool => tool.name === 'create_non_fungible_token_tool');

--- a/typescript/test/integration/tool-matching/create-topic-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-topic-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreConsensusPluginToolNames } from '@/plugins';
 
-describe('Create Topic Tool Matching Integration Tests', () => {
+describe.skip('Create Topic Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Create Topic Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match create topic tool with default params', async () => {
       const input = 'Create a new topic';
 
@@ -80,7 +80,7 @@ describe('Create Topic Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have create topic tool available', () => {
       const tools = toolkit.getTools();
       const createTopic = tools.find(tool => tool.name === 'create_topic_tool');

--- a/typescript/test/integration/tool-matching/delete-account-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/delete-account-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Delete Account Tool Matching Integration Tests', () => {
+describe.skip('Delete Account Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Delete Account Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match delete account tool with accountId only', async () => {
       const input = 'Delete account 0.0.12345';
 
@@ -81,7 +81,7 @@ describe('Delete Account Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have delete account tool available', () => {
       const tools = toolkit.getTools();
       const deleteAccount = tools.find(tool => tool.name === 'delete_account_tool');

--- a/typescript/test/integration/tool-matching/delete-topic-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/delete-topic-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { DELETE_TOPIC_TOOL } from '@/plugins/core-consensus-plugin/tools/consensus/delete-topic';
 
-describe('Delete Topic Tool Matching Integration Tests', () => {
+describe.skip('Delete Topic Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/dissociate-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/dissociate-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { DISSOCIATE_TOKEN_TOOL } from '@/plugins/core-token-plugin/tools/dissociate-token';
 
-describe('Dissociate Token Tool Matching Integration Tests', () => {
+describe.skip('Dissociate Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Dissociate Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match dissociate token tool with a single tokenId', async () => {
       const input = 'Dissociate token 0.0.12345 from my account';
 
@@ -83,7 +83,7 @@ describe('Dissociate Token Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have dissociate token tool available in the toolkit', () => {
       const tools = toolkit.getTools();
       const dissociateTool = tools.find(tool => tool.name === DISSOCIATE_TOKEN_TOOL);

--- a/typescript/test/integration/tool-matching/get-account-query-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-account-query-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { GET_ACCOUNT_QUERY_TOOL } from '@/plugins/core-account-query-plugin/tools/queries/get-account-query';
 
-describe('Get Account Query Tool Matching Integration Tests', () => {
+describe.skip('Get Account Query Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Get Account Query Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match get account query tool for simple request', async () => {
       const input = 'Get account info for 0.0.1234';
 
@@ -85,7 +85,7 @@ describe('Get Account Query Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have get account query tool available', () => {
       const tools = toolkit.getTools();
       const accountQueryTool = tools.find(tool => tool.name === 'get_account_query_tool');

--- a/typescript/test/integration/tool-matching/get-account-token-balances-tool-matching.integraion.test.ts
+++ b/typescript/test/integration/tool-matching/get-account-token-balances-tool-matching.integraion.test.ts
@@ -6,7 +6,7 @@ import { coreAccountQueryPluginToolNames } from '@/plugins';
 
 const { GET_ACCOUNT_TOKEN_BALANCES_QUERY_TOOL } = coreAccountQueryPluginToolNames;
 
-describe('Get Account Token Balances - Tool Matching Integration Tests', () => {
+describe.skip('Get Account Token Balances - Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/get-contract-info-query-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-contract-info-query-tool-matching.integration.test.ts
@@ -6,7 +6,7 @@ import { coreEVMQueryPluginToolNames } from '@/plugins';
 
 const { GET_CONTRACT_INFO_QUERY_TOOL } = coreEVMQueryPluginToolNames;
 
-describe('Get Contract Info - Tool Matching Integration Tests', () => {
+describe.skip('Get Contract Info - Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/get-exchange-rate-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-exchange-rate-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreMiscQueriesPluginsToolNames } from '@/plugins';
 
-describe('Get Exchange Rate Tool Matching Integration Tests', () => {
+describe.skip('Get Exchange Rate Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/get-hbar-balance-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-hbar-balance-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountQueryPluginToolNames } from '@/plugins';
 
-describe('Get HBAR Balance Tool Matching Integration Tests', () => {
+describe.skip('Get HBAR Balance Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/get-token-info-query-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-token-info-query-tool-matching.integration.test.ts
@@ -6,7 +6,7 @@ import { coreTokenQueryPluginToolNames } from 'hedera-agent-kit';
 
 const { GET_TOKEN_INFO_QUERY_TOOL } = coreTokenQueryPluginToolNames;
 
-describe('Get Token Info Query Tool Matching Integration Tests', () => {
+describe.skip('Get Token Info Query Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/get-topic-info-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-topic-info-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { GET_TOPIC_INFO_QUERY_TOOL } from '@/plugins/core-consensus-query-plugin/tools/queries/get-topic-info-query';
 
-describe('Get Topic Info Tool Matching Integration Tests', () => {
+describe.skip('Get Topic Info Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Get Topic Info Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match get topic info tool for simple request', async () => {
       const input = 'Get topic info for 0.0.1234';
 
@@ -68,7 +68,7 @@ describe('Get Topic Info Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have get topic info tool available', () => {
       const tools = toolkit.getTools();
       const tool = tools.find(tool => tool.name === 'get_topic_info_query_tool');

--- a/typescript/test/integration/tool-matching/get-topic-messages-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-topic-messages-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { GET_TOPIC_MESSAGES_QUERY_TOOL } from '@/plugins/core-consensus-query-plugin/tools/queries/get-topic-messages-query';
 
-describe('Get Topic Messages Tool Matching Integration Tests', () => {
+describe.skip('Get Topic Messages Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Get Topic Messages Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match get topic messages tool for simple request', async () => {
       const input = 'Get messages for topic 0.0.1234';
 
@@ -85,7 +85,7 @@ describe('Get Topic Messages Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have get topic messages tool available', () => {
       const tools = toolkit.getTools();
       const topicMessagesTool = tools.find(tool => tool.name === 'get_topic_messages_query_tool');

--- a/typescript/test/integration/tool-matching/get-transaction-record-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/get-transaction-record-tool-matching.integration.test.ts
@@ -6,7 +6,7 @@ import { coreTransactionQueryPluginToolNames } from '@/plugins';
 
 const { GET_TRANSACTION_RECORD_QUERY_TOOL } = coreTransactionQueryPluginToolNames;
 
-describe('Get Transaction Record - Tool Matching Integration Tests', () => {
+describe.skip('Get Transaction Record - Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;

--- a/typescript/test/integration/tool-matching/mint-erc721-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/mint-erc721-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { MINT_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/mint-erc721';
 
-describe('Mint ERC721 Tool Matching Integration Tests', () => {
+describe.skip('Mint ERC721 Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Mint ERC721 Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match simple mint ERC721 command with EVM address', async () => {
       const input = 'Mint ERC721 token 0.0.5678 to 0x1234567890123456789012345678901234567890';
 
@@ -108,7 +108,7 @@ describe('Mint ERC721 Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have mint ERC721 tool available', () => {
       const tools = toolkit.getTools();
       const mintERC721 = tools.find(tool => tool.name === 'mint_erc721_tool');

--- a/typescript/test/integration/tool-matching/mint-fungible-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/mint-fungible-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreTokenPluginToolNames } from '@/plugins';
 
-describe('Mint Fungible Token Tool Matching Integration Tests', () => {
+describe.skip('Mint Fungible Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Mint Fungible Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match mint fungible token tool with minimal params', async () => {
       const input = 'Mint 10 of token 0.0.12345';
 
@@ -78,7 +78,7 @@ describe('Mint Fungible Token Tool Matching Integration Tests', () => {
     }, 120_000); // increase timeout to 2 minutes
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have mint fungible token tool available', () => {
       const tools = toolkit.getTools();
       const mintFT = tools.find(tool => tool.name === 'mint_fungible_token_tool');

--- a/typescript/test/integration/tool-matching/mint-non-fungible-token-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/mint-non-fungible-token-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreTokenPluginToolNames } from '@/plugins';
 
-describe('Mint Non-Fungible Token Tool Matching Integration Tests', () => {
+describe.skip('Mint Non-Fungible Token Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Mint Non-Fungible Token Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match mint NFT tool with single URI', async () => {
       const input =
         'Mint 0.0.5005 with metadata: ipfs://bafyreiao6ajgsfji6qsgbqwdtjdu5gmul7tv2v3pd6kjgcw5o65b2ogst4/metadata.json';
@@ -95,7 +95,7 @@ describe('Mint Non-Fungible Token Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have mint non-fungible token tool available', () => {
       const tools = toolkit.getTools();
       const mintNFT = tools.find(tool => tool.name === 'mint_non_fungible_token_tool');

--- a/typescript/test/integration/tool-matching/schedule-delete-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/schedule-delete-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Schedule Delete Tool Matching Integration Tests', () => {
+describe.skip('Schedule Delete Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Schedule Delete Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match schedule delete tool for simple delete request', async () => {
       const input = 'Delete the scheduled transaction with ID 0.0.123456';
 
@@ -96,7 +96,7 @@ describe('Schedule Delete Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have schedule delete tool available', () => {
       const tools = toolkit.getTools();
       const tool = tools.find(t => t.name === 'schedule_delete_tool');

--- a/typescript/test/integration/tool-matching/sign-schedule-transaction-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/sign-schedule-transaction-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Sign Schedule Transaction Tool Matching Integration Tests', () => {
+describe.skip('Sign Schedule Transaction Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Sign Schedule Transaction Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match sign schedule transaction tool for simple sign request', async () => {
       const input = 'Sign the scheduled transaction with ID 0.0.123456';
 
@@ -215,7 +215,7 @@ describe('Sign Schedule Transaction Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have sign schedule transaction tool available', () => {
       const tools = toolkit.getTools();
       const signScheduleTransactionTool = tools.find(

--- a/typescript/test/integration/tool-matching/transfer-erc20-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/transfer-erc20-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { TRANSFER_ERC20_TOOL } from '@/plugins/core-evm-plugin/tools/erc20/transfer-erc20';
 
-describe('Transfer ERC20 Tool Matching Integration Tests', () => {
+describe.skip('Transfer ERC20 Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Transfer ERC20 Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match simple transfer ERC20 command', async () => {
       const input =
         'Transfer 100 0.0.5678 ERC20 tokens from contract to 0x1234567890123456789012345678901234567890';
@@ -174,7 +174,7 @@ describe('Transfer ERC20 Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have transfer ERC20 tool available', () => {
       const tools = toolkit.getTools();
       const transferERC20 = tools.find(tool => tool.name === 'transfer_erc20_tool');

--- a/typescript/test/integration/tool-matching/transfer-erc721-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/transfer-erc721-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { TRANSFER_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/transfer-erc721';
 
-describe('Transfer ERC721 Tool Matching Integration Tests', () => {
+describe.skip('Transfer ERC721 Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -25,7 +25,7 @@ describe('Transfer ERC721 Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match simple transfer ERC721 command', async () => {
       const input =
         'Transfer ERC721 token 1 from contract 0.0.5678 from 0.0.1234 to 0x1234567890123456789012345678901234567890';
@@ -210,7 +210,7 @@ describe('Transfer ERC721 Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have transfer ERC721 tool available', () => {
       const tools = toolkit.getTools();
       const transferERC721 = tools.find(tool => tool.name === 'transfer_erc721_tool');

--- a/typescript/test/integration/tool-matching/transfer-hbar-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/transfer-hbar-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Transfer HBAR Tool Matching Integration Tests', () => {
+describe.skip('Transfer HBAR Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -26,7 +26,7 @@ describe('Transfer HBAR Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match transfer HBAR tool for simple transfer request', async () => {
       const input = 'Transfer 1 HBAR to 0.0.1';
 
@@ -223,7 +223,7 @@ describe('Transfer HBAR Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have transfer HBAR tool available', () => {
       const tools = toolkit.getTools();
       const transferHbarTool = tools.find(tool => tool.name === 'transfer_hbar_tool');

--- a/typescript/test/integration/tool-matching/update-account-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/update-account-tool-matching.integration.test.ts
@@ -4,7 +4,7 @@ import { HederaLangchainToolkit } from '@/langchain';
 import { createLangchainTestSetup, type LangchainTestSetup } from '../../utils';
 import { coreAccountPluginToolNames } from '@/plugins';
 
-describe('Update Account Tool Matching Integration Tests', () => {
+describe.skip('Update Account Tool Matching Integration Tests', () => {
   let testSetup: LangchainTestSetup;
   let agentExecutor: AgentExecutor;
   let toolkit: HederaLangchainToolkit;
@@ -27,7 +27,7 @@ describe('Update Account Tool Matching Integration Tests', () => {
     }
   });
 
-  describe('Tool Matching and Parameter Extraction', () => {
+  describe.skip('Tool Matching and Parameter Extraction', () => {
     it('should match update account tool with memo update', async () => {
       const input = 'Update account 0.0.1234 memo to "Updated Memo"';
 
@@ -104,7 +104,7 @@ describe('Update Account Tool Matching Integration Tests', () => {
     });
   });
 
-  describe('Tool Available', () => {
+  describe.skip('Tool Available', () => {
     it('should have update account tool available', () => {
       const tools = toolkit.getTools();
       const updateAccount = tools.find(tool => tool.name === 'update_account_tool');

--- a/typescript/test/setup/slowdown.ts
+++ b/typescript/test/setup/slowdown.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach } from 'vitest';
+import { beforeEach } from 'vitest';
 
 const DEFAULT_DELAY_MS = 500;
 
@@ -15,7 +15,12 @@ const delayMs = getDelayMs();
 // If delay is zero, don't register hook to avoid overhead.
 if (delayMs > 0) {
   console.log(`Slowing down tests by ${delayMs}ms`);
-  beforeEach(async () => {
+  beforeEach(async (ctx) => {
+    const currentFilepath = ctx?.task?.file?.filepath ?? '';
+    // Skip slowdown for Hedera integration tests
+    if (currentFilepath.includes('/integration/hedera/')) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, delayMs));
   });
 }


### PR DESCRIPTION
… because of LLM dependency and api limits

**Description**: Temporary workaround
**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
