### PR TITLE
fix: rename repository in the package.json

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -74,7 +74,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hashgraph/hedera-agent-kit.git"
+    "url": "git+https://github.com/hashgraph/hedera-agent-kit-js.git"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
**Description**:
Rename the repository link in the package.json to avoid issues with the semantic release

**Related issue(s)**:
--

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
